### PR TITLE
lib.rs: restore default SIGPIPE signal handler

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -25,8 +25,6 @@ use std::os::unix::net::UnixStream;
 use thiserror::Error;
 use uucore::display::Quotable;
 use uucore::error::UResult;
-#[cfg(not(target_os = "windows"))]
-use uucore::libc;
 use uucore::translate;
 use uucore::{fast_inc::fast_inc_one, format_usage};
 
@@ -222,15 +220,6 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    // When we receive a SIGPIPE signal, we want to terminate the process so
-    // that we don't print any error messages to stderr. Rust ignores SIGPIPE
-    // (see https://github.com/rust-lang/rust/issues/62569), so we restore it's
-    // default action here.
-    #[cfg(not(target_os = "windows"))]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let number_mode = if matches.get_flag(options::NUMBER_NONBLANK) {

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -18,8 +18,6 @@ use native_int_str::{
     Convert, NCvt, NativeIntStr, NativeIntString, NativeStr, from_native_int_representation_owned,
 };
 #[cfg(unix)]
-use nix::libc;
-#[cfg(unix)]
 use nix::sys::signal::{SigHandler::SigIgn, Signal, signal};
 use std::borrow::Cow;
 use std::env;
@@ -845,12 +843,6 @@ fn ignore_signal(sig: Signal) -> UResult<()> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    // Rust ignores SIGPIPE (see https://github.com/rust-lang/rust/issues/62569).
-    // We restore its default action here.
-    #[cfg(unix)]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
     EnvAppData::default().run_env(args)
 }
 

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -30,6 +30,7 @@ uucore = { workspace = true, features = [
   "format",
   "parser",
   "quoting-style",
+  "signals",
 ] }
 fluent = { workspace = true }
 

--- a/src/uu/seq/src/error.rs
+++ b/src/uu/seq/src/error.rs
@@ -36,6 +36,11 @@ pub enum SeqError {
         translate!("seq-error-format-and-equal-width")
     )]
     FormatAndEqualWidth,
+
+    /// Failed to set signal handler
+    #[cfg(unix)]
+    #[error("failed to set signal handler")]
+    SignalHandler,
 }
 
 fn parse_error_type(e: &ParseNumberError) -> String {

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/split.rs"
 [dependencies]
 clap = { workspace = true }
 memchr = { workspace = true }
-uucore = { workspace = true, features = ["fs", "parser-size"] }
+uucore = { workspace = true, features = ["fs", "parser-size", "signals"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
 

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -40,15 +40,6 @@ use uucore::{show, show_error};
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    // When we receive a SIGPIPE signal, we want to terminate the process so
-    // that we don't print any error messages to stderr. Rust ignores SIGPIPE
-    // (see https://github.com/rust-lang/rust/issues/62569), so we restore it's
-    // default action here.
-    #[cfg(not(target_os = "windows"))]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-
     let settings = parse_args(args)?;
 
     settings.check_warnings();

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -19,7 +19,7 @@ use uucore::{format_usage, show_error};
 // spell-checker:ignore nopipe
 
 #[cfg(unix)]
-use uucore::signals::{enable_pipe_errors, ignore_interrupts};
+use uucore::signals::{enable_pipe_errors, ignore_interrupts, ignore_pipe};
 
 mod options {
     pub const APPEND: &str = "append";
@@ -164,6 +164,9 @@ fn tee(options: &Options) -> Result<()> {
         }
         if options.output_error.is_none() {
             enable_pipe_errors().map_err(|_| Error::from(ErrorKind::Other))?;
+        } else {
+            // When --output-error is set, ignore SIGPIPE to handle broken pipes gracefully
+            ignore_pipe().map_err(|_| Error::from(ErrorKind::Other))?;
         }
     }
     let mut writers: Vec<NamedWriter> = options

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -18,8 +18,6 @@ use std::io::{stdin, stdout};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::fs::is_stdin_directory;
-#[cfg(not(target_os = "windows"))]
-use uucore::libc;
 use uucore::translate;
 use uucore::{format_usage, os_str_as_bytes, show};
 
@@ -33,15 +31,6 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    // When we receive a SIGPIPE signal, we want to terminate the process so
-    // that we don't print any error messages to stderr. Rust ignores SIGPIPE
-    // (see https://github.com/rust-lang/rust/issues/62569), so we restore it's
-    // default action here.
-    #[cfg(not(target_os = "windows"))]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let delete_flag = matches.get_flag(options::DELETE);

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/tty.rs"
 [dependencies]
 clap = { workspace = true }
 nix = { workspace = true, features = ["term"] }
-uucore = { workspace = true, features = ["fs"] }
+uucore = { workspace = true, features = ["fs", "signals"] }
 fluent = { workspace = true }
 
 [[bin]]

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -12,12 +12,22 @@ use uucore::format_usage;
 
 use uucore::translate;
 
+#[cfg(unix)]
+use uucore::signals::ignore_pipe;
+
 mod options {
     pub const SILENT: &str = "silent";
 }
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    #[cfg(unix)]
+    {
+        // Ignore SIGPIPE so that broken pipes return EPIPE errors instead of
+        // killing the process. This allows tty to handle write failures gracefully
+        // and exit with code 3 when stdout fails, matching GNU tty behavior.
+        ignore_pipe().ok();
+    }
     let matches = uucore::clap_localization::handle_clap_result_with_exit_code(uu_app(), args, 2)?;
 
     let silent = matches.get_flag(options::SILENT);

--- a/src/uucore/src/lib/features/signals.rs
+++ b/src/uucore/src/lib/features/signals.rs
@@ -426,6 +426,14 @@ pub fn ignore_interrupts() -> Result<(), Errno> {
     unsafe { signal(SIGINT, SigIgn) }.map(|_| ())
 }
 
+/// Ignores the SIGPIPE signal.
+#[cfg(unix)]
+pub fn ignore_pipe() -> Result<(), Errno> {
+    // We pass the error as is, the return value would just be Ok(SigIgn), so we can safely ignore it.
+    // SAFETY: this function is safe as long as we do not use a custom SigHandler -- we use the default one.
+    unsafe { signal(SIGPIPE, SigIgn) }.map(|_| ())
+}
+
 #[test]
 fn signal_by_value() {
     assert_eq!(signal_by_name_or_value("0"), Some(0));

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1251,13 +1251,20 @@ fn test_final_stats_more_than_one_kb() {
 
 #[test]
 fn test_final_stats_three_char_limit() {
-    let result = new_ucmd!().pipe_in("0".repeat(10_000)).succeeds();
+    // Use of=/dev/null to avoid SIGPIPE when stdout pipe closes before dd finishes writing
+    let result = new_ucmd!()
+        .arg("of=/dev/null")
+        .pipe_in("0".repeat(10_000))
+        .succeeds();
     let s = result.stderr_str();
     assert!(
         s.starts_with("19+1 records in\n19+1 records out\n10000 bytes (10 kB, 9.8 KiB) copied,")
     );
 
-    let result = new_ucmd!().pipe_in("0".repeat(100_000)).succeeds();
+    let result = new_ucmd!()
+        .arg("of=/dev/null")
+        .pipe_in("0".repeat(100_000))
+        .succeeds();
     let s = result.stderr_str();
     assert!(
         s.starts_with("195+1 records in\n195+1 records out\n100000 bytes (100 kB, 98 KiB) copied,")


### PR DESCRIPTION
lib.rs: restore default SIGPIPE signal handler
    
Rust's start-up code sets the SIGPIPE signal handler to ignored. However the
vast majority of the utilities should use the default signal handler for
SIGPIPE.
    
Instead of restoring the default signaler handler in individual utilities, do it in lib.rs
and add some logic in the utilities which can't use the default SIGPIPE signal handler (cat, env, seq, split, tail, tee, tr, tty).